### PR TITLE
解决视频标题跑马灯bug

### DIFF
--- a/app/src/main/java/com/dueeeke/dkplayer/widget/controller/StandardVideoController.java
+++ b/app/src/main/java/com/dueeeke/dkplayer/widget/controller/StandardVideoController.java
@@ -351,6 +351,8 @@ public class StandardVideoController extends GestureVideoController implements V
     }
 
     private void show(int timeout) {
+        if (sysTime != null)
+            sysTime.setText(getCurrentSystemTime());
         if (!mShowing) {
             if (mediaPlayer.isFullScreen()) {
                 lock.setVisibility(VISIBLE);
@@ -391,8 +393,6 @@ public class StandardVideoController extends GestureVideoController implements V
             return 0;
         }
 
-        if (sysTime != null)
-            sysTime.setText(getCurrentSystemTime());
         if (title != null && TextUtils.isEmpty(title.getText())) {
             title.setText(mediaPlayer.getTitle());
         }


### PR DESCRIPTION
由于每次更新进度条的时候都设置时间，导致跑马灯效果不能正常显示，改为当展现的时候设置
一次时间即可，不影响跑马灯效果